### PR TITLE
feat: Add console warnings for misconfigured options

### DIFF
--- a/honeycomb/opentelemetry/options.py
+++ b/honeycomb/opentelemetry/options.py
@@ -186,7 +186,7 @@ class HoneycombOptions:
     metrics_dataset = None
     enable_local_visualizations = False
 
-    # pylint: disable=too-many-locals,too-many-branches
+    # pylint: disable=too-many-locals,too-many-branches,too-many-statements
     def __init__(
         self,
         apikey: str = None,


### PR DESCRIPTION
## Which problem is this PR solving?
Adds missing console warnings for misconfigured options.

- Closes #17 

## Short description of the changes
- Add warnings for missing API keys or service, dataset for non-classic API key and no dataset for classic API key
- Ignores the `too-many-statements` lint rule in HoneycombOptions

## How to verify that this has the expected result
Warnings are printed for misconfigured options.