### PR TITLE
bug: Don’t overwrite metrics exporter interval and timeout values

### DIFF
--- a/honeycomb/opentelemetry/metrics.py
+++ b/honeycomb/opentelemetry/metrics.py
@@ -37,15 +37,13 @@ def create_meter_provider(options: HoneycombOptions, resource: Resource):
         )
     readers = [
         PeriodicExportingMetricReader(
-            exporter,
-            export_timeout_millis=10000  # TODO set via OTEL env var
+            exporter
         )
     ]
     if options.debug:
         readers.append(
             PeriodicExportingMetricReader(
                 ConsoleMetricExporter(),
-                export_timeout_millis=10000  # TODO set via OTEL env var
             )
         )
     return MeterProvider(


### PR DESCRIPTION
## Which problem is this PR solving?
We should not overwrite the default interval and timeout properties when configuring meter readers, both when sending over OTLP and debug. Instead, if the values are not set, the default from the repspective env var will be used.

[OTEL_METRIC_EXPORT_INTERVAL](https://github.com/open-telemetry/opentelemetry-python/blob/0f9cfdd3b60914e6779aa6d09a58915565d89389/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/export/__init__.py#L444) - defaults is 60 seconds
[OTEL_METRIC_EXPORT_TIMEOUT](https://github.com/open-telemetry/opentelemetry-python/blob/0f9cfdd3b60914e6779aa6d09a58915565d89389/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/export/__init__.py#L454) - defaults  30 seconds

- Closes #50

## Short description of the changes
- Don't set values for interval or timeout when configuring a meter reader for OTLP or console exporters

## How to verify that this has the expected result
The default interval and timeout is used for meter readers and can be altered using the appropriate env var.