### PR TITLE
feat: Get version from package metadata

### DIFF
--- a/honeycomb/opentelemetry/version.py
+++ b/honeycomb/opentelemetry/version.py
@@ -1,2 +1,2 @@
-# TODO - get from pyproject.toml
-__version__ = "0.1.0"
+import pkg_resources
+__version__ = pkg_resources.get_distribution('honeycomb-opentelemetry').version


### PR DESCRIPTION
## Which problem is this PR solving?
Currently the package version is set via a custom string set in version.py. To make maintenance easier, instead we should use the package metadata to get the version.

## Short description of the changes
- Get the version from the package metadata instead of using a constant string

## How to verify that this has the expected result
The version of the package follows the version in pyproject.toml