### PR TITLE
maint: add prefix to dependabot prs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,6 @@ updates:
       - "type: dependencies"
     reviewers:
       - "honeycombio/telemetry-team"
+    commit-message:
+      prefix: "maint"
+      include: "scope"


### PR DESCRIPTION
## Which problem is this PR solving?

- Closes #64 

## Short description of the changes

dependabot file was already created; this PR just adds the `maint:` prefix so they pass our PR Title Validator check

## How to verify that this has the expected result

new dependabot PRs should be prepended with `maint:`