### PR TITLE
maint: add coverage report html to circleci artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ jobs:
       - store_test_results:
           path: test-results
       - store_artifacts:
-          path: test-reports
+          path: htmlcov
   build:
     executor:
       name: python/default

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ jobs:
       - store_test_results:
           path: test-results
       - store_artifacts:
-          path: htmlcov
+          path: test-reports
   build:
     executor:
       name: python/default

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,8 @@ jobs:
       - run: make test
       - store_test_results:
           path: test-results
+      - store_artifacts:
+          path: htmlcov
   build:
     executor:
       name: python/default

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,8 +60,10 @@ jobs:
       - run: make test
       - store_test_results:
           path: test-results
+          destination: junit.xml
       - store_artifacts:
-          path: test-reports
+          path: test-results
+          destination: coverage.xml
   build:
     executor:
       name: python/default

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,10 +60,8 @@ jobs:
       - run: make test
       - store_test_results:
           path: test-results
-          destination: junit.xml
       - store_artifacts:
-          path: test-results
-          destination: coverage.xml
+          path: test-reports
   build:
     executor:
       name: python/default

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,6 @@ bin
 
 .vscode
 .coverage
+htmlcov
 .env
 test-results/
-test-reports/

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,6 @@ bin
 
 .vscode
 .coverage
-htmlcov
 .env
 test-results/
+test-reports/

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,8 @@ clean: clean-smoke-tests clean-cache
 test: build
 	mkdir -p test-results
 	unset ${OUR_CONFIG_ENV_VARS} && poetry run pytest tests --junitxml=test-results/junit.xml 
-	poetry run coverage xml -o test-results/coverage.xml
+	mkdir -p test-reports
+	poetry run coverage report && poetry run coverage xml -o test-reports/coverage.xml
 
 #: nitpick lint
 lint: install_dev

--- a/Makefile
+++ b/Makefile
@@ -37,10 +37,12 @@ clean-cache:
 #: clean smoke test output, caches, builds
 clean: clean-smoke-tests clean-cache
 
-#: run the unit tests with a clean environment
+#: run the unit tests with a clean environment, create coverage report html
 test: build
 	mkdir -p test-results
 	unset ${OUR_CONFIG_ENV_VARS} && poetry run pytest tests --junitxml=test-results/junit.xml
+	poetry run coverage html
+
 
 #: nitpick lint
 lint: install_dev

--- a/Makefile
+++ b/Makefile
@@ -40,9 +40,9 @@ clean: clean-smoke-tests clean-cache
 #: run the unit tests with a clean environment, create coverage report html
 test: build
 	mkdir -p test-results
-	unset ${OUR_CONFIG_ENV_VARS} && poetry run pytest tests --junitxml=test-results/junit.xml
-	poetry run coverage html
-
+	unset ${OUR_CONFIG_ENV_VARS} && poetry run pytest tests --junitxml=test-results/junit.xml 
+	mkdir -p test-reports
+	poetry run coverage report && poetry run coverage xml -o test-reports/coverage.xml
 
 #: nitpick lint
 lint: install_dev

--- a/Makefile
+++ b/Makefile
@@ -41,8 +41,7 @@ clean: clean-smoke-tests clean-cache
 test: build
 	mkdir -p test-results
 	unset ${OUR_CONFIG_ENV_VARS} && poetry run coverage run -m pytest tests --junitxml=test-results/junit.xml 
-	mkdir -p test-reports
-	poetry run coverage xml -o test-reports/coverage.xml
+	poetry run coverage html
 
 #: nitpick lint
 lint: install_dev

--- a/Makefile
+++ b/Makefile
@@ -41,8 +41,7 @@ clean: clean-smoke-tests clean-cache
 test: build
 	mkdir -p test-results
 	unset ${OUR_CONFIG_ENV_VARS} && poetry run pytest tests --junitxml=test-results/junit.xml 
-	mkdir -p test-reports
-	poetry run coverage report && poetry run coverage xml -o test-reports/coverage.xml
+	poetry run coverage xml -o test-results/coverage.xml
 
 #: nitpick lint
 lint: install_dev

--- a/Makefile
+++ b/Makefile
@@ -40,9 +40,9 @@ clean: clean-smoke-tests clean-cache
 #: run the unit tests with a clean environment, create coverage report html
 test: build
 	mkdir -p test-results
-	unset ${OUR_CONFIG_ENV_VARS} && poetry run pytest tests --junitxml=test-results/junit.xml 
+	unset ${OUR_CONFIG_ENV_VARS} && poetry run coverage run -m pytest tests --junitxml=test-results/junit.xml 
 	mkdir -p test-reports
-	poetry run coverage report && poetry run coverage xml -o test-reports/coverage.xml
+	poetry run coverage xml -o test-reports/coverage.xml
 
 #: nitpick lint
 lint: install_dev


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Closes #84 

## Short description of the changes
Improves maintainability!  Uses coverage.py to run our test suite and compare it to our src directory to find un-covered features. Uploads the report as an interactive html to CircleCI artifacts.

## How to verify that this has the expected result
In CircleCI, under a test workflow, go to the Artifacts tab and find the [htmlcov/index.html](https://output.circle-artifacts.com/output/job/ff865a0e-797d-4482-998f-e33a1ef90b7d/artifacts/0/htmlcov/index.html) for code coverage. It's interactive to find different functions in files we haven't covered in testing!
