### PR TITLE
feat: allow HONEYCOMB_API_ENDPOINT as an Option parsed as an environment variable

### DIFF
--- a/src/honeycomb/opentelemetry/options.py
+++ b/src/honeycomb/opentelemetry/options.py
@@ -14,7 +14,6 @@ from opentelemetry.sdk.environment_variables import (
     OTEL_SERVICE_NAME
 )
 from grpc import ssl_channel_credentials
-OTEL_SERVICE_VERSION = "OTEL_SERVICE_VERSION"
 
 # Environment Variable Names
 OTEL_SERVICE_VERSION = "OTEL_SERVICE_VERSION"
@@ -24,6 +23,7 @@ SAMPLE_RATE = "SAMPLE_RATE"
 
 # HNY Credential Names
 HONEYCOMB_API_KEY = "HONEYCOMB_API_KEY"
+HONEYCOMB_API_ENDPOINT = "HONEYCOMB_API_ENDPOINT"
 HONEYCOMB_TRACES_APIKEY = "HONEYCOMB_TRACES_APIKEY"
 HONEYCOMB_DATASET = "HONEYCOMB_DATASET"
 HONEYCOMB_METRICS_APIKEY = "HONEYCOMB_METRICS_APIKEY"
@@ -196,6 +196,7 @@ class HoneycombOptions:
     metrics_apikey = None
     service_name = DEFAULT_SERVICE_NAME
     service_version = None
+    endpoint = DEFAULT_API_ENDPOINT
     traces_endpoint = None
     metrics_endpoint = None
     traces_endpoint_insecure = False
@@ -296,8 +297,11 @@ class HoneycombOptions:
             _logger.warning(INVALID_EXPORTER_PROTOCOL_ERROR)
             self.metrics_exporter_protocol = exporter_protocol
 
-        # if http/protobuf protocol and using generic env or param
-        # append /v1/traces path
+        endpoint = os.environ.get(
+            HONEYCOMB_API_ENDPOINT,
+            DEFAULT_API_ENDPOINT
+        )
+
         self.traces_endpoint = os.environ.get(
             OTEL_EXPORTER_OTLP_TRACES_ENDPOINT,
             None

--- a/src/honeycomb/opentelemetry/options.py
+++ b/src/honeycomb/opentelemetry/options.py
@@ -319,7 +319,7 @@ class HoneycombOptions:
                 if not self.traces_endpoint:
                     self.traces_endpoint = _append_traces_path(
                         self.traces_exporter_protocol,
-                        self.endpoint or DEFAULT_API_ENDPOINT
+                        self.endpoint
                     )
 
         # if http/protobuf protocol and using generic env or param
@@ -338,7 +338,7 @@ class HoneycombOptions:
                 if not self.metrics_endpoint:
                     self.metrics_endpoint = _append_metrics_path(
                         self.metrics_exporter_protocol,
-                        self.endpoint or DEFAULT_API_ENDPOINT
+                        self.endpoint
                     )
 
         self.sample_rate = parse_int(

--- a/src/honeycomb/opentelemetry/options.py
+++ b/src/honeycomb/opentelemetry/options.py
@@ -299,11 +299,11 @@ class HoneycombOptions:
 
         self.endpoint = os.environ.get(
             HONEYCOMB_API_ENDPOINT,
-            None
+            endpoint
         )
 
         if not self.endpoint:
-            self.endpoint = endpoint or DEFAULT_API_ENDPOINT
+            self.endpoint = DEFAULT_API_ENDPOINT
 
         self.traces_endpoint = os.environ.get(
             OTEL_EXPORTER_OTLP_TRACES_ENDPOINT,

--- a/src/honeycomb/opentelemetry/options.py
+++ b/src/honeycomb/opentelemetry/options.py
@@ -297,10 +297,13 @@ class HoneycombOptions:
             _logger.warning(INVALID_EXPORTER_PROTOCOL_ERROR)
             self.metrics_exporter_protocol = exporter_protocol
 
-        endpoint = os.environ.get(
+        self.endpoint = os.environ.get(
             HONEYCOMB_API_ENDPOINT,
-            DEFAULT_API_ENDPOINT
+            None
         )
+
+        if not self.endpoint:
+            self.endpoint = endpoint or DEFAULT_API_ENDPOINT
 
         self.traces_endpoint = os.environ.get(
             OTEL_EXPORTER_OTLP_TRACES_ENDPOINT,
@@ -316,7 +319,7 @@ class HoneycombOptions:
                 if not self.traces_endpoint:
                     self.traces_endpoint = _append_traces_path(
                         self.traces_exporter_protocol,
-                        endpoint or DEFAULT_API_ENDPOINT
+                        self.endpoint or DEFAULT_API_ENDPOINT
                     )
 
         # if http/protobuf protocol and using generic env or param
@@ -335,7 +338,7 @@ class HoneycombOptions:
                 if not self.metrics_endpoint:
                     self.metrics_endpoint = _append_metrics_path(
                         self.metrics_exporter_protocol,
-                        endpoint or DEFAULT_API_ENDPOINT
+                        self.endpoint or DEFAULT_API_ENDPOINT
                     )
 
         self.sample_rate = parse_int(

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -51,11 +51,19 @@ def test_can_set_service_name_with_envvar(monkeypatch):
     options = HoneycombOptions()
     assert options.service_name == "my-service"
 
+
 def test_can_set_generic_api_endpoint_with_envvar(monkeypatch):
     monkeypatch.setenv(HONEYCOMB_API_ENDPOINT, EXPECTED_ENDPOINT)
     options = HoneycombOptions()
     assert options.get_traces_endpoint() == EXPECTED_ENDPOINT
     assert options.get_metrics_endpoint() == EXPECTED_ENDPOINT
+
+
+def test_can_set_generic_api_endpoint_with_param():
+    options = HoneycombOptions(endpoint=EXPECTED_ENDPOINT)
+    assert options.get_traces_endpoint() == EXPECTED_ENDPOINT
+    assert options.get_metrics_endpoint() == EXPECTED_ENDPOINT
+
 
 def test_can_set_traces_endpoint_with_param():
     options = HoneycombOptions(traces_endpoint=EXPECTED_ENDPOINT)
@@ -453,7 +461,7 @@ def test_get_traces_endpoint_with_grpc_protocol_returns_correctly_formatted_endp
 
 
 def test_get_traces_endpoint_with_http_proto_protocol_returns_correctly_formatted_endpoint(monkeypatch):
-    #http
+    # http
     protocol = EXPORTER_PROTOCOL_HTTP_PROTO
 
     # default endpoint
@@ -511,7 +519,7 @@ def test_get_metrics_endpoint_with_grpc_protocol_returns_correctly_formatted_end
 
 
 def test_get_metrics_endpoint_with_http_proto_protocol_returns_correctly_formatted_endpoint(monkeypatch):
-    #http
+    # http
     protocol = EXPORTER_PROTOCOL_HTTP_PROTO
 
     # default endpoint

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -14,6 +14,7 @@ from honeycomb.opentelemetry.options import (
     EXPORTER_PROTOCOL_GRPC,
     EXPORTER_PROTOCOL_HTTP_PROTO,
     HoneycombOptions,
+    HONEYCOMB_API_ENDPOINT,
     HONEYCOMB_API_KEY,
     HONEYCOMB_DATASET,
     HONEYCOMB_ENABLE_LOCAL_VISUALIZATIONS,
@@ -50,6 +51,11 @@ def test_can_set_service_name_with_envvar(monkeypatch):
     options = HoneycombOptions()
     assert options.service_name == "my-service"
 
+def test_can_set_generic_api_endpoint_with_envvar(monkeypatch):
+    monkeypatch.setenv(HONEYCOMB_API_ENDPOINT, EXPECTED_ENDPOINT)
+    options = HoneycombOptions()
+    assert options.get_traces_endpoint() == EXPECTED_ENDPOINT
+    assert options.get_metrics_endpoint() == EXPECTED_ENDPOINT
 
 def test_can_set_traces_endpoint_with_param():
     options = HoneycombOptions(traces_endpoint=EXPECTED_ENDPOINT)


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Closes #98 

## Short description of the changes
Parses HONEYCOMB_API_ENDPOINT as an option. 

## How to verify that this has the expected result
In the hello-world-flask app, try something like `DEBUG=TRUE HONEYCOMB_API_ENDPOINT=http://collector:4317 OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf OTEL_EXPORTER_OTLP_METRICS_ENDPOINT=http://custom.metrics:666 poetry run opentelemetry-instrument flask run` to see the expected endpoint resolution:

```
'traces_exporter_protocol': 'http/protobuf', 
'metrics_exporter_protocol': 'http/protobuf',
 'endpoint': 'http://collector:4317', 
'traces_endpoint': 'http://collector:4317/v1/traces', 
'metrics_endpoint': 'http://custom.metrics:666', 
// not expected to append /v1/metrics for http protocol w/ specifically declared OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
```