### PR TITLE
maint: Revert "maint(deps-dev): bump pylint from 2.15.10 to 2.16.0"

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2,20 +2,20 @@
 
 [[package]]
 name = "astroid"
-version = "2.14.1"
+version = "2.13.2"
 description = "An abstract syntax tree for Python with inference support."
 category = "dev"
 optional = false
 python-versions = ">=3.7.2"
 files = [
-    {file = "astroid-2.14.1-py3-none-any.whl", hash = "sha256:23c718921acab5f08cbbbe9293967f1f8fec40c336d19cd75dc12a9ea31d2eb2"},
-    {file = "astroid-2.14.1.tar.gz", hash = "sha256:bd1aa4f9915c98e8aaebcd4e71930154d4e8c9aaf05d35ac0a63d1956091ae3f"},
+    {file = "astroid-2.13.2-py3-none-any.whl", hash = "sha256:8f6a8d40c4ad161d6fc419545ae4b2f275ed86d1c989c97825772120842ee0d2"},
+    {file = "astroid-2.13.2.tar.gz", hash = "sha256:3bc7834720e1a24ca797fd785d77efb14f7a28ee8e635ef040b6e2d80ccb3303"},
 ]
 
 [package.dependencies]
 lazy-object-proxy = ">=1.4.0"
 typed-ast = {version = ">=1.4.0,<2.0", markers = "implementation_name == \"cpython\" and python_version < \"3.8\""}
-typing-extensions = {version = ">=4.0.0", markers = "python_version < \"3.11\""}
+typing-extensions = ">=4.0.0"
 wrapt = [
     {version = ">=1.11,<2", markers = "python_version < \"3.11\""},
     {version = ">=1.14,<2", markers = "python_version >= \"3.11\""},
@@ -710,18 +710,18 @@ files = [
 
 [[package]]
 name = "pylint"
-version = "2.16.0"
+version = "2.15.10"
 description = "python code static checker"
 category = "dev"
 optional = false
 python-versions = ">=3.7.2"
 files = [
-    {file = "pylint-2.16.0-py3-none-any.whl", hash = "sha256:55e5cf00601c4cfe2e9404355c743a14e63be85df7409da7e482ebde5f9f14a1"},
-    {file = "pylint-2.16.0.tar.gz", hash = "sha256:43ee36c9b690507ef9429ce1802bdc4dcde49454c3d665e39c23791567019c0a"},
+    {file = "pylint-2.15.10-py3-none-any.whl", hash = "sha256:9df0d07e8948a1c3ffa3b6e2d7e6e63d9fb457c5da5b961ed63106594780cc7e"},
+    {file = "pylint-2.15.10.tar.gz", hash = "sha256:b3dc5ef7d33858f297ac0d06cc73862f01e4f2e74025ec3eff347ce0bc60baf5"},
 ]
 
 [package.dependencies]
-astroid = ">=2.14.1,<=2.16.0-dev0"
+astroid = ">=2.12.13,<=2.14.0-dev0"
 colorama = {version = ">=0.4.5", markers = "sys_platform == \"win32\""}
 dill = [
     {version = ">=0.2", markers = "python_version < \"3.11\""},
@@ -1014,4 +1014,4 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7, >= 3.7.2"
-content-hash = "77b9703018bfbc6c8a31894b243b513416b7c3eb29c901979a8e5c56b77fda10"
+content-hash = "1ea4c96a5399b6d1623c0897de58c7c66a1c4113e9d7ec457b249f77fdd945e9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ opentelemetry-instrumentation = "^0.36b0"
 [tool.poetry.group.dev.dependencies]
 coverage = "^6.5.0"
 pytest = "^7.2.0"
-pylint = "^2.16.0"
+pylint = "^2.15.7"
 pycodestyle = "^2.10.0"
 importlib-metadata = { version = ">=0.12", python = "<3.8" }
 requests-mock = "^1.10.0"


### PR DESCRIPTION
Reverts honeycombio/honeycomb-opentelemetry-python#70

We have some fuckery with the dockerizing of the flask app and upgrading dependencies in an open PR. This bump is causing some merge conflicts and it seems easiest to revert and change separately.