### PR TITLE
ci: require smoke tests for publish steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,9 +168,11 @@ workflows:
           <<: *filters_publish
           context: Honeycomb Secrets for Public Repos
           requires:
+            - smoke_test
             - build
       - publish_pypi:
           <<: *filters_publish
           context: Honeycomb Secrets for Public Repos
           requires:
+            - smoke_test
             - build


### PR DESCRIPTION
## Which problem is this PR solving?
While releasing an alpha version I noticed that [PyPI and GitHub release steps fired before smoke tests were finished](https://app.circleci.com/pipelines/github/honeycombio/honeycomb-opentelemetry-python/308/workflows/a2d867dc-4ba7-40d8-88fd-4bf4040abcf8) so I updated the release steps to require smoke tests pass.

## Short description of the changes
- Add `smoke_tests` to set of required jobs for publish steps

## How to verify that this has the expected result
- publish a dev tag and check that smoke tests finish running before release steps can happen
