### PR TITLE
maint: add tests for auto instrumentation

### DIFF
--- a/smoke-tests/smoke-sdk-grpc-flask.bats
+++ b/smoke-tests/smoke-sdk-grpc-flask.bats
@@ -9,7 +9,7 @@ TRACER_NAME="hello_world_flask_tracer"
 METER_NAME="hello_world_flask_meter"
 
 setup_file() {
-    docker-compose up --build --detach collector ${CONTAINER_NAME}
+	docker-compose up --build --detach collector ${CONTAINER_NAME}
 	wait_for_ready_app ${CONTAINER_NAME}
 	curl --silent localhost:5000
 	wait_for_traces
@@ -24,6 +24,11 @@ teardown_file() {
 }
 
 # TESTS
+
+@test "Auto instrumentation produces a flask span" {
+  result=$(span_names_for "opentelemetry.instrumentation.flask")
+  assert_equal "$result" '"/"'
+}
 
 @test "Manual instrumentation produces parent and child spans with names of spans" {
 	result=$(span_names_for ${TRACER_NAME})

--- a/smoke-tests/smoke-sdk-http-flask.bats
+++ b/smoke-tests/smoke-sdk-http-flask.bats
@@ -9,7 +9,7 @@ TRACER_NAME="hello_world_flask_tracer"
 METER_NAME="hello_world_flask_meter"
 
 setup_file() {
-    docker-compose up --build --detach collector ${CONTAINER_NAME}
+	docker-compose up --build --detach collector ${CONTAINER_NAME}
 	wait_for_ready_app ${CONTAINER_NAME}
 	curl --silent localhost:5000
 	wait_for_traces
@@ -24,6 +24,11 @@ teardown_file() {
 }
 
 # TESTS
+
+@test "Auto instrumentation produces a flask span" {
+  result=$(span_names_for "opentelemetry.instrumentation.flask")
+  assert_equal "$result" '"/"'
+}
 
 @test "Manual instrumentation produces parent and child spans with names of spans" {
 	result=$(span_names_for ${TRACER_NAME})


### PR DESCRIPTION
## Which problem is this PR solving?

- Updates #109 

It seems like this is indeed working, and more digging should be done to figure out how we end up in a state where it doesn't work. This smoke test should at least give some confidence about it working in a container - specifically, an environment separate from our own computers.

## Short description of the changes

- Add tests to smoke tests for auto-instrumented spans for flask

## How to verify that this has the expected result

Smoke tests should pass with the auto-instrumented flask spans being tested