### PR TITLE
maint: add auto-merge dependabot workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,23 @@
+name: Dependabot auto-merge dev dependency patches
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1.3.6
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Enable auto-merge for Dependabot PRs for Dev Dependency Patch Updates
+        if: ${{contains(steps.metadata.outputs.dependency-type, 'direct:development') && steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
+        run: gh pr review --approve "$PR_URL" && gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
## Which problem is this PR solving?

- Lots of dependabots; auto-merging some subset of these may help ease some of the pain 

## Short description of the changes

Add dependabot auto-merge workflow.

Current state of this file:

- `github.actor == 'dependabot[bot]'` means only run for PRs authored by Dependabot
- `(steps.metadata.outputs.dependency-type, 'direct:development')` means only run on dev dependencies
- `steps.metadata.outputs.update-type == 'version-update:semver-patch'` means only run for patch updates
- `gh pr review --approve "$PR_URL"` means approve PRs that match the above conditions
- `gh pr merge --auto --merge "$PR_URL"` means merge PRs that match the above conditions

## How to verify that this has the expected result

After merging... In Insights / Dependency Graph / Dependabot, check for updates (or wait until the next weekly run). Any dev dependencies that have a patch update available should be auto-approved with this setup.