### PR TITLE
maint: change experimental badge to active

### DIFF
--- a/OSSMETADATA
+++ b/OSSMETADATA
@@ -1,1 +1,1 @@
-osslifecycle=experimental
+osslifecycle=active


### PR DESCRIPTION
## Which problem is this PR solving?

- Lifecycle badge still showed experimental; should be active now that this is a published beta package.

## Short description of the changes

- change experimental lifecycle status to active in `OSSMETADATA`, which gets pulled into the readme for the badge

## How to verify that this has the expected result

after merge, refresh readme to see active badge