### PR TITLE
maint: use squash merge for dependabot auto-merge

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -17,7 +17,7 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Enable auto-merge for Dependabot PRs for Dev Dependency Patch Updates
         if: ${{contains(steps.metadata.outputs.dependency-type, 'direct:development') && steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
-        run: gh pr review --approve "$PR_URL" && gh pr merge --auto --merge "$PR_URL"
+        run: gh pr review --approve "$PR_URL" && gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
## Which problem is this PR solving?

- previous attempts to auto-merge dev dependencies [failed](https://github.com/honeycombio/honeycomb-opentelemetry-python/actions/runs/4585202481/jobs/8097205347?pr=118) merge

## Short description of the changes

- update `--merge` flag to `--squash` [flag](https://cli.github.com/manual/gh_pr_merge)

## How to verify that this has the expected result

next dependabot should successfully auto-merge a passing dev patch update