### PR TITLE
rel: Prepare v0.2.0b0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # honeycomb-opentelemetry-python changelog
 
+## [0.2.0b0] - 2023-04-11
+
+### Maintenance
+
+826d7f15 maint: Update OTel packages to 1.17.0/0.38b0 (#127) | [@MikeGoldsmith](https://github.com/MikeGoldsmith)
+90caadb6 maint: Set opentelemetry to version 1.16.0 (#125) | [@guillemtrebol](https://github.com/guillemtrebol)
+f8e92fde maint: Use squash merge for dependabot auto-merge (#122) | [@JamieDanielson](https://github.com/JamieDanielson)
+e370c664 maint: Update readme status (#121) | [@vreynolds](https://github.com/vreynolds)
+d2048622 maint: Change experimental badge to active (#120) | [@JamieDanielson](https://github.com/JamieDanielson)
+22b31822 maint: Improve ci time (#114) | [@JamieDanielson](https://github.com/JamieDanielson)
+1df3e26f maint: Add auto-merge dependabot workflow (#113) | [@JamieDanielson](https://github.com/JamieDanielson)
+3f62d57c maint(deps-dev): bump pylint from 2.16.2 to 2.17.1 (#115)
+29b61d09 maint(deps-dev): bump pytest from 7.2.1 to 7.2.2 (#117)
+1a955972 maint(deps-dev): bump coverage from 7.2.1 to 7.2.3 (#126)
+60f5267c maint(deps-dev): bump importlib-metadata from 6.0.0 to 6.1.0 (#119)
+
 ## [0.1.2b0] - 2023-03-29
 
 Initial beta release of Honeycomb's OpenTelemetry distribution for Python!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,17 @@
 
 ### Maintenance
 
-826d7f15 maint: Update OTel packages to 1.17.0/0.38b0 (#127) | [@MikeGoldsmith](https://github.com/MikeGoldsmith)
-90caadb6 maint: Set opentelemetry to version 1.16.0 (#125) | [@guillemtrebol](https://github.com/guillemtrebol)
-f8e92fde maint: Use squash merge for dependabot auto-merge (#122) | [@JamieDanielson](https://github.com/JamieDanielson)
-e370c664 maint: Update readme status (#121) | [@vreynolds](https://github.com/vreynolds)
-d2048622 maint: Change experimental badge to active (#120) | [@JamieDanielson](https://github.com/JamieDanielson)
-22b31822 maint: Improve ci time (#114) | [@JamieDanielson](https://github.com/JamieDanielson)
-1df3e26f maint: Add auto-merge dependabot workflow (#113) | [@JamieDanielson](https://github.com/JamieDanielson)
-3f62d57c maint(deps-dev): bump pylint from 2.16.2 to 2.17.1 (#115)
-29b61d09 maint(deps-dev): bump pytest from 7.2.1 to 7.2.2 (#117)
-1a955972 maint(deps-dev): bump coverage from 7.2.1 to 7.2.3 (#126)
-60f5267c maint(deps-dev): bump importlib-metadata from 6.0.0 to 6.1.0 (#119)
+- maint: Update OTel packages to 1.17.0/0.38b0 (#127) | [@MikeGoldsmith](https://github.com/MikeGoldsmith)
+- maint: Set opentelemetry to version 1.16.0 (#125) | [@guillemtrebol](https://github.com/guillemtrebol)
+- maint: Use squash merge for dependabot auto-merge (#122) | [@JamieDanielson](https://github.com/JamieDanielson)
+- maint: Update readme status (#121) | [@vreynolds](https://github.com/vreynolds)
+- maint: Change experimental badge to active (#120) | [@JamieDanielson](https://github.com/JamieDanielson)
+- maint: Improve ci time (#114) | [@JamieDanielson](https://github.com/JamieDanielson)
+- maint: Add auto-merge dependabot workflow (#113) | [@JamieDanielson](https://github.com/JamieDanielson)
+- maint(deps-dev): bump pylint from 2.16.2 to 2.17.1 (#115)
+- maint(deps-dev): bump pytest from 7.2.1 to 7.2.2 (#117)
+- maint(deps-dev): bump coverage from 7.2.1 to 7.2.3 (#126)
+- maint(deps-dev): bump importlib-metadata from 6.0.0 to 6.1.0 (#119)
 
 ## [0.1.2b0] - 2023-03-29
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It makes getting started with OpenTelemetry and Honeycomb easier!
 
 Latest release built with:
 
-- [OpenTelemetry version 1.16.0/0.37b0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.16.0)
+- [OpenTelemetry version 1.17.0/0.38b0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.17.0)
 
 ## Requirements
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "honeycomb-opentelemetry"
-version = "0.1.2b0"
+version = "0.2.0b0"
 description = "Honeycomb OpenTelemetry Distro for Python"
 authors = ["Honeycomb <support@honeycomb.io>"]
 readme = "README.md"


### PR DESCRIPTION
## Which problem is this PR solving?
Prepares the v0.2.0b0 release.

## Short description of the changes
- Updates version to 0.2.0b0
- Adds changelog entry
- Updates README to show OTel SDK version used to build with

## How to verify that this has the expected result
