### PR TITLE
Don't init HoneycombOptions on import

### DIFF
--- a/src/honeycomb/opentelemetry/distro.py
+++ b/src/honeycomb/opentelemetry/distro.py
@@ -17,6 +17,7 @@ Typical usage example:
     )
 """
 from logging import getLogger
+from typing import Optional
 from opentelemetry.instrumentation.distro import BaseDistro
 from opentelemetry.metrics import set_meter_provider
 from opentelemetry.trace import set_tracer_provider
@@ -29,7 +30,7 @@ _logger = getLogger(__name__)
 
 
 def configure_opentelemetry(
-    options: HoneycombOptions = HoneycombOptions(),
+    options: Optional[HoneycombOptions] = None,
 ):
     """
     Configures the OpenTelemetry SDK to send telemetry to Honeycomb.
@@ -41,6 +42,8 @@ def configure_opentelemetry(
 
         Note: API key is a required option.
     """
+    if not options:
+        options = HoneycombOptions()
     _logger.info("🐝 Configuring OpenTelemetry using Honeycomb distro 🐝")
     _logger.debug(vars(options))
     resource = create_resource(options)

--- a/src/honeycomb/opentelemetry/distro.py
+++ b/src/honeycomb/opentelemetry/distro.py
@@ -42,7 +42,7 @@ def configure_opentelemetry(
 
         Note: API key is a required option.
     """
-    if not options:
+    if options is None:
         options = HoneycombOptions()
     _logger.info("🐝 Configuring OpenTelemetry using Honeycomb distro 🐝")
     _logger.debug(vars(options))

--- a/src/honeycomb/opentelemetry/sampler.py
+++ b/src/honeycomb/opentelemetry/sampler.py
@@ -14,7 +14,10 @@ from opentelemetry.trace.span import TraceState
 from opentelemetry.util.types import Attributes
 from opentelemetry.context import Context
 
-from honeycomb.opentelemetry.options import DEFAULT_SAMPLE_RATE, HoneycombOptions
+from honeycomb.opentelemetry.options import (
+    DEFAULT_SAMPLE_RATE,
+    HoneycombOptions
+)
 
 _logger = getLogger(__name__)
 

--- a/src/honeycomb/opentelemetry/sampler.py
+++ b/src/honeycomb/opentelemetry/sampler.py
@@ -1,4 +1,5 @@
 from logging import getLogger
+from typing import Optional
 
 from opentelemetry.sdk.trace.sampling import (
     ALWAYS_OFF,
@@ -13,13 +14,13 @@ from opentelemetry.trace.span import TraceState
 from opentelemetry.util.types import Attributes
 from opentelemetry.context import Context
 
-from honeycomb.opentelemetry.options import HoneycombOptions
+from honeycomb.opentelemetry.options import DEFAULT_SAMPLE_RATE, HoneycombOptions
 
 _logger = getLogger(__name__)
 
 
 def configure_sampler(
-    options: HoneycombOptions = HoneycombOptions(),
+    options: Optional[HoneycombOptions] = None,
 ):
     """Configures and returns an OpenTelemetry Sampler that is
     configured based on the sample_rate determined in HoneycombOptions.
@@ -37,6 +38,9 @@ def configure_sampler(
     Returns:
         DeterministicSampler: the configured Sampler based on sample_rate
     """
+    if options is None:
+        return DeterministicSampler(DEFAULT_SAMPLE_RATE)
+
     return DeterministicSampler(options.sample_rate)
 
 


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

Importing the honeycomb module throws these warnings.

```
WARNING:honeycomb.opentelemetry.options:Missing API key. Specify either HONEYCOMB_API_KEY environment variable or apikey in the optionsparameter.
WARNING:honeycomb.opentelemetry.options:Missing service name. Specify either OTEL_SERVICE_NAME environment variable or service_name in the options parameter. If left unset, this will show up in Honeycomb as unknown_service:python
```

## Short description of the changes

This side effect shouldn't happen at import time. I changed to use `None` as the default value, and handle the value when the function is invoked.

## How to verify that this has the expected result

This can be verified by running the hello world example in the project, or this simpler reproducible snippet:

```python
import logging

logging.basicConfig(level=logging.DEBUG)

from honeycomb.opentelemetry.options import HoneycombOptions
```
