### PR TITLE
maint: Add nightly tests job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,13 +148,13 @@ jobs:
 
 workflows:
   nightly:
-    # triggers:
-    #   - schedule:
-    #       cron: "0 0 * * *"
-    #       filters:
-    #         branches:
-    #           only:
-    #             - main
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - main
     jobs:
       - test:
           <<: *matrix_python_versions

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ jobs:
 
   smoke_test:
     machine:
-      image: ubuntu-2004:202107-02
+      image: ubuntu-2004:2023.04.2
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,6 +147,21 @@ jobs:
           command: make publish
 
 workflows:
+  nightly:
+    # triggers:
+    #   - schedule:
+    #       cron: "0 0 * * *"
+    #       filters:
+    #         branches:
+    #           only:
+    #             - main
+    jobs:
+      - test:
+          <<: *matrix_python_versions
+      - smoke_test:
+          requires:
+            - test
+
   build:
     jobs:
       - lint

--- a/smoke-tests/docker-compose.yml
+++ b/smoke-tests/docker-compose.yml
@@ -31,7 +31,7 @@ x-flask-app-base:
 
 services:
   collector:
-    image: otel/opentelemetry-collector:0.52.0
+    image: otel/opentelemetry-collector:0.81.0
     command: [ "--config=/etc/otel-collector-config.yaml" ]
     volumes:
       - "./collector/otel-collector-config.yaml:/etc/otel-collector-config.yaml"


### PR DESCRIPTION
## Which problem is this PR solving?
Adds nightly test jobs and upgrades ubuntu and the collector version for smoke tests. It seems like this also fixes the failed smoke test issues we're seeing on main.

- Closes #145 

## Short description of the changes
- Added `nightly` workflow to CircleCI config
- Upgraded Ubuntu for smoke tests
- Upgraded collector version for smoke tests

## How to verify that this has the expected result
- [Nightly build runs tests](https://app.circleci.com/pipelines/github/honeycombio/honeycomb-opentelemetry-python/388/workflows/6b3f9ebe-f150-4abb-a524-238d214668e3)
- Not sure how to test the cron job will work exactly before we merge this in, but it is the same as on our other repos so I'm fairly confident it will be the same.

