### PR TITLE
maint: try using dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,13 @@ updates:
     commit-message:
       prefix: "maint"
       include: "scope"
+    groups:
+      testing-dependencies:
+        patterns:
+          - "coverage"
+          - "pytest"
+          - "importlib-metadata"
+          - "requests-mock"
+      otel:
+        patterns:
+          - "opentelemetry*"


### PR DESCRIPTION
## Which problem is this PR solving?

- updates https://github.com/honeycombio/telemetry-team/issues/487

## Short description of the changes

groups are in beta and allow configuring dependabot to open a single pr for grouped dependencies

trying grouping testing dependencies together, so that a passing test suite is enough to merge that group

grouping otel together, because more often than not we need to update all otel versions

## How to verify that this has the expected result

dependabot continues to run and we get fewer PRs
