### PR TITLE
fix: set shell to `bash` in `Makefile` to enable `unset`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+#: set shell to bash to make shell builtin behaviour consistent
+SHELL := /usr/bin/env bash
+
 #: install dependencies; set dev_only for only development dependencies or use the install_dev target
 install:
 ifeq ($(dev_only),) # dev_only not set


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Closes #69

## Short description of the changes

sets shell to bash to fix shell builtin behaviour

## How to verify that this has the expected result

run `make test` with a disruptive environment variable that starts with `HONEYCOMB_` or `OTEL_` set
