### PR TITLE
maint: Don’t append OTLP signal paths if already present

### DIFF
--- a/src/honeycomb/opentelemetry/options.py
+++ b/src/honeycomb/opentelemetry/options.py
@@ -78,8 +78,8 @@ log_levels = {
 EXPORTER_PROTOCOL_GRPC = "grpc"
 EXPORTER_PROTOCOL_HTTP_PROTO = "http/protobuf"
 
-TRACES_HTTP_PATH = "/v1/traces"
-METRICS_HTTP_PATH = "/v1/metrics"
+TRACES_HTTP_PATH = "v1/traces"
+METRICS_HTTP_PATH = "v1/metrics"
 
 exporter_protocols = {
     EXPORTER_PROTOCOL_GRPC,

--- a/src/honeycomb/opentelemetry/options.py
+++ b/src/honeycomb/opentelemetry/options.py
@@ -78,6 +78,9 @@ log_levels = {
 EXPORTER_PROTOCOL_GRPC = "grpc"
 EXPORTER_PROTOCOL_HTTP_PROTO = "http/protobuf"
 
+TRACES_HTTP_PATH = "/v1/traces"
+METRICS_HTTP_PATH = "/v1/metrics"
+
 exporter_protocols = {
     EXPORTER_PROTOCOL_GRPC,
     EXPORTER_PROTOCOL_HTTP_PROTO
@@ -155,26 +158,26 @@ def parse_int(environment_variable: str,
 def _append_traces_path(protocol: str, endpoint: str) -> str:
     """
     Appends the OTLP traces HTTP path '/v1/traces' to the endpoint if the
-    protocol is http/protobuf.
+    protocol is http/protobuf and it doesn't already exist.
 
     Returns:
         string: the endpoint, optionally appended with traces path
     """
-    if endpoint and protocol == "http/protobuf":
-        return "/".join([endpoint.strip("/"), "v1/traces"])
+    if endpoint and protocol == "http/protobuf" and not endpoint.strip("/").endswith(TRACES_HTTP_PATH):
+        return "/".join([endpoint.strip("/"), TRACES_HTTP_PATH])
     return endpoint
 
 
 def _append_metrics_path(protocol: str, endpoint: str) -> str:
     """
     Appends the OTLP metrics HTTP path '/v1/metrics' to the endpoint if the
-    protocol is http/protobuf.
+    protocol is http/protobuf and it doesn't already exist.
 
     Returns:
         string: the endpoint, optionally appended with metrics path
     """
-    if endpoint and protocol == "http/protobuf":
-        return "/".join([endpoint.strip("/"), "v1/metrics"])
+    if endpoint and protocol == "http/protobuf" and not endpoint.strip("/").endswith(METRICS_HTTP_PATH):
+        return "/".join([endpoint.strip("/"), METRICS_HTTP_PATH])
     return endpoint
 
 

--- a/src/honeycomb/opentelemetry/options.py
+++ b/src/honeycomb/opentelemetry/options.py
@@ -163,7 +163,8 @@ def _append_traces_path(protocol: str, endpoint: str) -> str:
     Returns:
         string: the endpoint, optionally appended with traces path
     """
-    if endpoint and protocol == "http/protobuf" and not endpoint.strip("/").endswith(TRACES_HTTP_PATH):
+    if endpoint and protocol == "http/protobuf" \
+       and not endpoint.strip("/").endswith(TRACES_HTTP_PATH):
         return "/".join([endpoint.strip("/"), TRACES_HTTP_PATH])
     return endpoint
 
@@ -176,7 +177,8 @@ def _append_metrics_path(protocol: str, endpoint: str) -> str:
     Returns:
         string: the endpoint, optionally appended with metrics path
     """
-    if endpoint and protocol == "http/protobuf" and not endpoint.strip("/").endswith(METRICS_HTTP_PATH):
+    if endpoint and protocol == "http/protobuf" \
+       and not endpoint.strip("/").endswith(METRICS_HTTP_PATH):
         return "/".join([endpoint.strip("/"), METRICS_HTTP_PATH])
     return endpoint
 

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -488,6 +488,16 @@ def test_get_traces_endpoint_with_http_proto_protocol_returns_correctly_formatte
     options = HoneycombOptions(exporter_protocol=protocol)
     assert options.get_traces_endpoint() == EXPECTED_ENDPOINT
 
+def test_get_traces_endpoint_with_traces_path_and_http_proto_returns_corretly_formatted_endpoint(monkeypatch):
+    # http
+    protocol = EXPORTER_PROTOCOL_HTTP_PROTO
+    
+    # endpoint already has /v1/traces
+    endpoint = EXPECTED_ENDPOINT + "/v1/traces"
+    
+    # set endpoint in options
+    options = HoneycombOptions(exporter_protocol=protocol, endpoint=endpoint)
+    assert options.get_traces_endpoint() == endpoint
 
 def test_get_metrics_endpoint_with_grpc_protocol_returns_correctly_formatted_endpoint(monkeypatch):
     # grpc
@@ -546,6 +556,16 @@ def test_get_metrics_endpoint_with_http_proto_protocol_returns_correctly_formatt
     options = HoneycombOptions(exporter_protocol=protocol)
     assert options.get_metrics_endpoint() == EXPECTED_ENDPOINT
 
+def test_get_metrics_endpoint_with_metrics_path_and_http_proto_returns_corretly_formatted_endpoint(monkeypatch):
+    # http
+    protocol = EXPORTER_PROTOCOL_HTTP_PROTO
+    
+    # endpoint already has /v1/metrics
+    endpoint = EXPECTED_ENDPOINT + "/v1/metrics"
+    
+    # set endpoint in options
+    options = HoneycombOptions(exporter_protocol=protocol, endpoint=endpoint)
+    assert options.get_metrics_endpoint() == endpoint
 
 def test_debug_sets_log_level_to_debug():
     options = HoneycombOptions(debug=True)

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -493,7 +493,7 @@ def test_get_traces_endpoint_with_traces_path_and_http_proto_returns_corretly_fo
     protocol = EXPORTER_PROTOCOL_HTTP_PROTO
     
     # endpoint already has /v1/traces
-    endpoint = EXPECTED_ENDPOINT + "/v1/traces"
+    endpoint = DEFAULT_API_ENDPOINT + "/v1/traces"
     
     # set endpoint in options
     options = HoneycombOptions(exporter_protocol=protocol, endpoint=endpoint)
@@ -561,7 +561,7 @@ def test_get_metrics_endpoint_with_metrics_path_and_http_proto_returns_corretly_
     protocol = EXPORTER_PROTOCOL_HTTP_PROTO
     
     # endpoint already has /v1/metrics
-    endpoint = EXPECTED_ENDPOINT + "/v1/metrics"
+    endpoint = DEFAULT_API_ENDPOINT + "/v1/metrics"
     
     # set endpoint in options
     options = HoneycombOptions(exporter_protocol=protocol, endpoint=endpoint)


### PR DESCRIPTION
## Which problem is this PR solving?
If an HTTP endpoint for traces or metrics already includes the signal path (eg /v1/traces or /v1/metrics), the path is added a second time (eg `http://somewhere.com/v1/traces` becomes `http://somewhere.com/v1/traces/v1/traces`).

The path should only be added if it doesn't already exist.

- Closes #155 

## Short description of the changes
- Update options.get_traces_endpoint and options.get_metrics_endpoint to check if the endpoint already ends with the signal path before adding it
- Add tests to verify behaviour

## How to verify that this has the expected result
You can now use an endpoint with a signal path and the signal path won't be added twice.