### PR TITLE
maint: update publish target for PyPI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ build: install
 
 #: build and publish a package
 publish: install
-	poetry publish -u honeycomb -p ${PYPI_PASSWORD}
+	poetry publish -u '__token__' -p ${PYPI_TOKEN}
 
 #: cleans up smoke test output
 clean-smoke-tests:


### PR DESCRIPTION
## Which problem is this PR solving?

- PyPI now requires API tokens instead of username/password for publishing packages which ([caused our last publish attempt to fail](https://app.circleci.com/pipelines/github/honeycombio/honeycomb-opentelemetry-python/655/workflows/2e762044-db51-4917-983b-0b3f637187b4/jobs/4412))

## Short description of the changes

- Update `make publish` to use new PyPI API token ([see PyPI docs here](https://pypi.org/help/#apitoken))

## How to verify that this has the expected result

Next publish attempt should be successful! Ran this command locally and it succeeded in showing this syntax is correct.