### PR TITLE
docs: Fix django example typos

### DIFF
--- a/examples/hello-world-django/README.md
+++ b/examples/hello-world-django/README.md
@@ -37,7 +37,7 @@ configure_opentelemetry(
 )
 ```
 
-This app will send traces to local console with the configured `debug=True`.
+Note: With `debug` set to `True`, spans will also be printed to stdout.
 
 To send to Honeycomb, set your API Key:
 

--- a/examples/hello-world-django/README.md
+++ b/examples/hello-world-django/README.md
@@ -25,7 +25,7 @@ Then navigate to http://127.0.0.1:8000 as shown in the command output and you sh
 ## Distro Instrumentation Example
 
 This app uses configuration configures the OpenTelemetry SDK programmatically in [manage.py](./manage.py).
-Alternitively, you can use environment variables as parameters like below:
+Alternatively, you can use environment variables as parameters like below:
 
 ```python
 configure_opentelemetry(
@@ -42,7 +42,7 @@ This app will send traces to local console with the configured `debug=True`.
 To send to Honeycomb, set your API Key:
 
 ```bash
-HONEYCOMB_API_KEY="your-api-key" poetry run python3 app.py
+HONEYCOMB_API_KEY="your-api-key" poetry run python manage.py runserver
 ```
 
 You can configure exporter protocol with this flag:


### PR DESCRIPTION
## Which problem is this PR solving?
Fixes a couple of typos in the Django example added in the following PR:
- #176 

## Short description of the changes
- Fix typos
- Update run command to match previous example

## How to verify that this has the expected result
Django example doesn't contain typos and commands execute as expected.