### PR TITLE
rel: prep release v0.4.2b0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # honeycomb-opentelemetry-python changelog
 
+## [0.4.2b0] - 2024-04-10
+
+The previous tag did not have the latest commit from main, so this is just a release to ensure the published release is using the commit from main. There are no actual functionality changes in this release.
+
 ## [0.4.1b0] - 2024-04-09
 
 ### Fixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "honeycomb-opentelemetry"
-version = "0.4.1b0"
+version = "0.4.2b0"
 description = "Honeycomb OpenTelemetry Distro for Python"
 authors = ["Honeycomb <support@honeycomb.io>"]
 readme = "README.md"


### PR DESCRIPTION
## Which problem is this PR solving?

- The previous tag used a commit from the release prep PR instead of main. Retagging to ensure we have the commit from main as the latest published release.

## Short description of the changes

- update changelog
- update version
