### PR TITLE
main: Make opentelemetry-instrumentation package version less restric…

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -994,4 +994,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7, >= 3.7.2"
-content-hash = "359641b4b23972217cc3df7ff2a1003927990a94ca61410fecde7ecf8dacb18b"
+content-hash = "a9803a233ed9f4c9a01c68e5f3ddc2fb7ae77167ffb3aef902aca5a751d0c590"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ python = "^3.7, >= 3.7.2"
 opentelemetry-api = "^1.22.0"
 opentelemetry-sdk = "^1.22.0"
 opentelemetry-exporter-otlp = "^1.22.0"
-opentelemetry-instrumentation = "~0.43b0"
+opentelemetry-instrumentation = "^0.43b0"
 
 [tool.poetry.group.dev.dependencies]
 coverage = ">=6.5,<8.0"


### PR DESCRIPTION
## Which problem is this PR solving?
The dependency on `opentelemetry-instrumentation` is overly restrictive and doesn't allow later minor versions to be used. For example, it's set as `~0.43b0` but doesn't allow the latest releases `0.44b0` or `0.45b0`.

This is because the [tilde](https://python-poetry.org/docs/dependency-specification/#tilde-requirements) `~` version constraint doesn't allow versions that change within the same semver point specified. The version we set is `0.43b0`, which means it can't go higher than minor release `0.43b0` and subsequent packages are minor releases. It would allow patch version of the same minor if they were published, eg `0.43b0.x`.

- Closes #195 

## Short description of the changes
- Update `opentelemetry-instrumentation` package version constraint to use the [caret](https://python-poetry.org/docs/dependency-specification/#caret-requirements) `^` prefix instead, which is equivalent to >= 0.43b0 and < 1.0

## How to verify that this has the expected result
Later version of opentelemetry-instrumentation package can be used with the distro.